### PR TITLE
Fix read limitation

### DIFF
--- a/bin/modbus-ws.js
+++ b/bin/modbus-ws.js
@@ -31,6 +31,8 @@ program
     .option('-P, --tcpport <number>', 'Server port number [3000]', numberRegex, 3000)
     .option('-c, --nocache', 'Do not use caching for modbus comunication. [false]', false)
     .option('-w, --nohttp', 'Run only websocket server, no httpd. [false]', false)
+    .option('-m, --maxlength <number>', 'Max registers/coils to read in one modbus request. [10]', numberRegex, 10)
+
     .on('--help', function(){
         console.log('  Examples:');
         console.log('');


### PR DESCRIPTION
When making a read request for more than 10 coils (FC1), only 10 will be returned. This is due to a default limitation in the cache.js ("MAX_LENGTH"). It affects both registers and coils.

I must admit that I don't understand why this limitation exists. The standard allows much higher limits. In my opinion, the user should at least have the opportunity to alter this parameter via command line.